### PR TITLE
updating ch 5 q 8 to redirect stdout from one proc to stdin of another

### DIFF
--- a/Chapter 5/question8.c
+++ b/Chapter 5/question8.c
@@ -1,66 +1,67 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
-#include <stdlib.h>
+#include <fcntl.h>
 #include <sys/wait.h>
+#define BUFSZE 32
 
-int main()
+/* #8 Write a program that creates two children, and connects the standard
+output of one to the standard input of the other, using the
+pipe() system call */
+
+int
+main(int argc, char *argv[])
 {
-    int pipefd[2];
+    // Setup our pipe
+    char buff[BUFSZE];
+    int p[2];
 
-    if (pipe(pipefd) == -1)
-    {
-        printf("Error occurred during creation of pipe\n");
-    }
-    int rc = fork();
+    if (pipe(p) < 0)
+      exit(1);
 
-    if (rc == -1)
-    {
-        fprintf(stderr, "Error ocurred during fork()");
-    }
-    else if (rc == 0) // first child process
-    {
-        close(pipefd[0]); // We don't want to read
-        dup2(pipefd[1], fileno(stdout)); // Redirecting pipe_write <- stdout
-    
-        printf("I am first child process\n");
+    int rc1 = fork();
+    if (rc1 < 0) {
+        // fork failed; exit
+        fprintf(stderr, "fork #1 failed\n");
+        exit(1);
+    } else if (rc1 == 0) {
+	     // Child #1
+       printf(" Child #1 ");
+       close(p[0]);   // This one only writes
+       dup2(p[1], 1); // redirect stdout to pipe write
+       printf("_This is getting sent to the pipe_");
+    } else {
+        // Parent process
+        int rc2 = fork();
+        if (rc2 < 0) {
+          fprintf(stderr, "fork #2 failed\n");
+          exit(1);
+        } else if (rc2 == 0) {
+          // Child #2
+          printf(" Child #2 ");
+          close(p[1]);      // Only read here
+          dup2(p[0], 0);    // Redirect stdin to pipe read
 
-        exit(0);
-    }
-    else
-    {
-        int rc_2 = fork();
+          /* Strangely it looks like ALL of the stdout from
+           * fork 1 is being sent to the pipe, even the stuff
+           * sent to stdout BEFORE dup2 is called. This can be
+           * shown by adjusting the size of the buffer below
+           * to something small like 6 and seeing what gets
+           * printed out... weird! */
 
-        if (rc_2 == -1)
-        {
-            fprintf(stderr, "Error occurred during fork() for 2nd process\n");
+          char buff[512];   // Make a buffer
+          read(STDIN_FILENO, buff, 512); // Read in from stdin
+          printf("%s", buff);     // Print out buffer
+
+        } else {
+          // Initial parent process
+          /* If we wait for rc1 then it could finish before rc2 is done,
+           * giving us some strange behavior. */
+
+          int wc = waitpid(rc2, NULL, 0);
+          printf("goodbye");
         }
-        else if (rc_2 == 0) // 2nd Child
-        {
-            char * buffer = (char *)malloc(100);
-            close(pipefd[1]); // I don't want to write
-            
-            read(pipefd[0], buffer, 100); // pipefd[0] -> buffer
-            
-            if (write(fileno(stdin), buffer, 100) == -1)
-            {
-                printf("Some error occurred during writing to std_out\n");
-            }
-
-            printf("I am second child\n");
-            printf("OUTPUT of FIRST CHILD: %s", buffer);
-            free((void *)buffer);
-            exit(0);
-        }
-        else
-        {
-            char * std_out_of_first_child = (char *) malloc(100);
-            wait(NULL);
-            close(pipefd[1]); // We don't want to write anything
-            read(pipefd[0], std_out_of_first_child, 100);
-            printf("I am parent process and facilitating redirection of 1st child\nprocess std_output to 2nd child process std_input\n");
-            free((void *)std_out_of_first_child);
-        }
-        
     }
+    return 0;
 }


### PR DESCRIPTION
Your solution was really good but like you said, it was only reading directly from the pipe in the second fork. This solution redirects stdout from fork #1 to stdin of fork #2, I think it's a better answer to the question. What do you think?