### PR TITLE
Changed answer, there should be 2 instead of N

### DIFF
--- a/Chapter 7/README.md
+++ b/Chapter 7/README.md
@@ -194,4 +194,4 @@ If we doubles each job length, average response time also get double too. It mea
 ### What happens to response time with RR as quantum lengths increase? Can you write an equation that gives the worst-case response time, given N jobs?
 
 Response time increases linearly with quantum length increase.
-Let N be the number of jobs and q the quantum length, then the worst-case response time is (N-1)q/N.
+Let N be the number of jobs and q the quantum length, then the worst-case response time is (N-1)q/2.


### PR DESCRIPTION
Worst case response time in RR with N jobs should be (N-1)q/2 instead of (N-1)q/N as given in the solution.

This is because - sum of all response times will be 0q + 1q + 2q + .... + (N-1)q = N(N-1)q/2, hence average response time is (N-1)q/2

Additionally, (N-1)q/N response time would make the response time shorter than the quantum length.